### PR TITLE
Update vi_func.py

### DIFF
--- a/vi_func.py
+++ b/vi_func.py
@@ -1007,6 +1007,7 @@ def vsarea(obj, vs):
 def wind_rose(wro, maxws, wrsvg, wrtype, colors):
     zp = 0
     bm = bmesh.new()
+    vs = []
 #    wro.select_set(True)
     wro.location = (0, 0, 0)
     svg = minidom.parse(wrsvg)


### PR DESCRIPTION
Assigned an empty value to _vs_ variable because in some cases I get "Local Variable Referenced Before Assignment" error on line 1053 

`bmesh.ops.remove_doubles(bm, verts=vs, dist=scale * 0.01)`